### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,8 @@
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/majorsilence/CrystalCmd/security/code-scanning/7](https://github.com/majorsilence/CrystalCmd/security/code-scanning/7)

In general, the fix is to add an explicit `permissions` block that grants only the minimal permissions needed for the job or entire workflow, instead of relying on repository/organization defaults. For build‑and‑test workflows that do not modify repository contents or manage issues/PRs, `contents: read` is usually sufficient.

The best fix here, without altering existing functionality, is to add a top‑level `permissions` block just under the workflow `name:` (or equivalently under `on:`) so that it applies to all jobs. The steps in `windows-build` only check out code, install tools, run a build, upload artifacts, and generate test reports; none of these require write access to the repository, so setting `permissions: contents: read` is safe. Concretely, in `.github/workflows/dotnet.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `name: .NET` line (line 1). No additional imports or other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
